### PR TITLE
Fixes for GPU Interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ and copies it to the proper destination.
     $ git clone https://github.com/RRZE-HPC/pylikwid.git
     $ cd pylikwid
     # Build C interface
+    # NVIDIA functions enabled by -DLIKWID_NVMON
     $ python setup.py build_ext -I <include path for likwid> -L <library path for likwid> -R <library path for likwid>
     # Install module to the proper location
     $ python setup.py install (--prefix=<where to install>)

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,8 @@ def get_hierarchy():
 
 try:
     LIKWID_PREFIX, LIKWID_LIBPATH, LIKWID_LIB, LIKWID_INCPATH = get_hierarchy()
+    # TODO
+    major, minor, release = (5, 3, 2)
     print(LIKWID_PREFIX, LIKWID_LIBPATH, LIKWID_LIB, LIKWID_INCPATH)
 except Exception as e:
     print(e)
@@ -105,6 +107,7 @@ pylikwid = Extension("pylikwid",
                      include_dirs=[LIKWID_INCPATH],
                      libraries=[LIKWID_LIB],
                      library_dirs=[LIKWID_LIBPATH],
+                     define_macros=[("LIKWID_MAJOR", major), ("LIKWID_MINOR", minor), (("LIKWID_RELEASE", release))],
                      sources=["pylikwid.c"])
 
 setup(


### PR DESCRIPTION
Hello,

I discovered minor bugs in the GPU API that caused pylikwid to fail when building/importing:

- Added hard-coded macros to setup.py specifying the LIKWID version
- Minor bug fixes in GPU-related functions in pylikwid.c
- Disabled functions with undefined symbols to liblikwid.so
- Added a hint to the README to enable -DLIKWID_NVMON when building the package

Please feel free to provide more sophisticated solutions to my temporary fixes.