### PR TITLE
Add likwid 5.4 compatibility

### DIFF
--- a/pylikwid.c
+++ b/pylikwid.c
@@ -699,7 +699,11 @@ likwid_initaffinity(PyObject *self, PyObject *args)
     for(i = 0; i < (int)affinity->numberOfAffinityDomains; i++)
     {
         PyObject *a = PyDict_New();
+#if (LIKWID_MAJOR == 5 && LIKWID_RELEASE >= 4)
+        PyDict_SetItem(a, PYSTR("tag"), PYSTR(affinity->domains[i].tag));
+#else
         PyDict_SetItem(a, PYSTR("tag"), PYSTR(bdata(affinity->domains[i].tag)));
+#endif
         PyDict_SetItem(a, PYSTR("numberOfProcessors"), PYINT(affinity->domains[i].numberOfProcessors));
         PyDict_SetItem(a, PYSTR("numberOfCores"), PYINT(affinity->domains[i].numberOfCores));
         PyObject *l = PyList_New(affinity->domains[i].numberOfProcessors);

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ def get_extra_compile_args():
                 f"-DLIKWID_RELEASE={release}",
                 f"-DLIKWID_MINOR={minor}",
             ])
+            break
     return extra_args
 
 

--- a/setup.py
+++ b/setup.py
@@ -101,10 +101,27 @@ except Exception as e:
     sys.exit(1)
 
 
+def get_extra_compile_args():
+    extra_args = []
+    likwid_header_path = f"{LIKWID_INCPATH}/likwid.h"
+    with open(likwid_header_path, mode="r") as f:
+        for line in f:
+            if not line.startswith("#define LIKWID_VERSION"):
+                continue
+            major, release, minor = line.split()[-1].strip("\"").split(".")
+            extra_args.extend([
+                f"-DLIKWID_MAJOR={major}",
+                f"-DLIKWID_RELEASE={release}",
+                f"-DLIKWID_MINOR={minor}",
+            ])
+    return extra_args
+
+
 pylikwid = Extension("pylikwid",
                      include_dirs=[LIKWID_INCPATH],
                      libraries=[LIKWID_LIB],
                      library_dirs=[LIKWID_LIBPATH],
+                     extra_compile_args=get_extra_compile_args(),
                      sources=["pylikwid.c"])
 
 setup(


### PR DESCRIPTION
This updates `likwid_initaffinity` to disable the use of `bdata` for Likwid releases starting with 5.4, fixing incompatibility issues like the one described in [this issue](https://github.com/RRZE-HPC/pylikwid/issues/19).

To pass the appropriate Likwid version information to the pylikwid build process, we simply scan the Likwid include file for the respective major and minor release versions and pass them as additional build arguments. If there's a more elegant way to do this, feel free to let me know @TomTheBear and I'll implement it if you'd like :)