### PR TITLE
Reorganize repo and use `pyproject.toml`

### DIFF
--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -23,10 +23,12 @@ jobs:
         sudo modprobe msr
     - name: Install
       run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install setuptools
-        python3 setup.py build_ext
+        python3 -m pip install --upgrade pip setuptools
         python3 -m pip install -e .
+    - name: Debug LIKWID libs
+      run: |
+        ls /usr/local/lib/liblik* /usr/local/lib/libbstr* || true
+        nm -D /usr/local/lib/liblikwid.so | grep bdata || true
     - name: Test
       run: |
         export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
@@ -36,7 +38,8 @@ jobs:
         ./tests/testaffinity.py
     - name: Build package
       run: |
-        python setup.py build sdist
+        python3 -m pip install build
+        python3 -m build
     - name: Publish to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 *.pyc
 *.so
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include LICENSE
 include README.rst
-include pylikwid.c
+include src/pylikwid/pylikwid.c
 include tests/*.py

--- a/pylikwid.c
+++ b/pylikwid.c
@@ -885,6 +885,8 @@ likwid_getClockCycles(PyObject *self, PyObject *args)
         timer_init();
         timer_initialized = 1;
     }
+    timer.start.int64 = start;
+    timer.stop.int64 = stop;
     return Py_BuildValue("K", timer_printCycles(&timer));
 }
 
@@ -902,6 +904,8 @@ likwid_getClock(PyObject *self, PyObject *args)
         timer_init();
         timer_initialized = 1;
     }
+    timer.start.int64 = start;
+    timer.stop.int64 = stop;
     return Py_BuildValue("d", timer_print(&timer));
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+
+requires = [ "setuptools>=61" ]
+
+[project]
+name = "pylikwid"
+version = "0.4.2"
+description = "A Python module to access the function of the LIKWID library"
+readme = "README.rst"
+keywords = [ "analysis", "benchmark", "hpc", "performance" ]
+license = { file = "LICENSE" }
+authors = [
+  { name = "Thomas Roehl", email = "thomas.roehl@googlemail.com" },
+]
+requires-python = ">=3.8"
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Software Development",
+  "Topic :: Utilities",
+]
+
+optional-dependencies.test = [ "pytest" ]
+urls.Homepage = "https://github.com/RRZE-HPC/pylikwid"
+
+[tool.setuptools]
+packages = [ "pylikwid" ]
+package-dir = { "" = "src" }
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os, os.path, glob, re, sys
-from distutils.core import setup, Extension
-
+from setuptools import setup, Extension
 
 # Utility function to read the README.md file.
 # Used for the long_description.  It"s nice, because now 1) we have a top level

--- a/setup.py
+++ b/setup.py
@@ -135,13 +135,36 @@ def get_include_dirs():
         include_dirs.append(likwid_subdir)
     return include_dirs
 
+def get_sources():
+    sources = ["src/pylikwid/pylikwid.c"]
+
+    # bstrlib was added directly into 5.4 and is only needed for older versions
+    lib = ctypes.CDLL(os.path.join(LIKWID_LIBPATH, "liblikwid.so"))
+    lib.likwid_getMajorVersion.restype = ctypes.c_int
+    lib.likwid_getMinorVersion.restype = ctypes.c_int
+    major = lib.likwid_getMajorVersion()
+    release = lib.likwid_getMinorVersion()
+
+    if not (major == 5 and release >= 4):
+        for candidate in [
+            os.path.join(LIKWID_INCPATH, "bstrlib.c"),
+            "/usr/local/include/bstrlib.c",
+            "/usr/include/bstrlib.c",
+        ]:
+            if os.path.exists(candidate):
+                print(f"Adding bstrlib from {candidate} (LIKWID {major}.{release})")
+                sources.append(candidate)
+                break
+
+    return sources
+
 pylikwid = Extension("pylikwid.pylikwid",
                      include_dirs=get_include_dirs(),
                      libraries=get_libraries(),
                      library_dirs=[LIKWID_LIBPATH],
                      runtime_library_dirs=[LIKWID_LIBPATH],
                      extra_compile_args=get_extra_compile_args(),
-                     sources = ["src/pylikwid/pylikwid.c"],
+                     sources=get_sources(),
                      py_limited_api=True,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,7 @@
+import glob
 import os, os.path, glob, re, sys
-from setuptools import setup, Extension
-
-# Utility function to read the README.md file.
-# Used for the long_description.  It"s nice, because now 1) we have a top level
-# README.md file and 2) it"s easier to type in the README.md file than to put a raw
-# string in below ...
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
+from setuptools import setup, Extension, find_packages
+import ctypes
 
 ver_regex = re.compile(r"so.(\d+)[.]*(\d*)")
 
@@ -107,58 +101,58 @@ def get_extra_compile_args():
     if os.environ.get("LIKWID_NVMON") not in (None, "0"):
         extra_args.append("-DLIKWID_NVMON")
 
-    # Add likwid version definitions from likwid.h.
-    likwid_header_path = f"{LIKWID_INCPATH}/likwid.h"
-    with open(likwid_header_path) as f:
-        for line in f:
-            if not line.startswith("#define LIKWID_VERSION"):
-                continue
-            major, release, minor = line.split()[-1].strip('"').split(".")
-            extra_args.extend([
-                f"-DLIKWID_MAJOR={major}",
-                f"-DLIKWID_RELEASE={release}",
-                f"-DLIKWID_MINOR={minor}",
-            ])
-            break
+    # Query version directly from the library using the exported symbols
+    libpath = os.path.join(LIKWID_LIBPATH, "liblikwid.so")
+    lib = ctypes.CDLL(libpath)
+    lib.likwid_getMajorVersion.restype = ctypes.c_int
+    lib.likwid_getMinorVersion.restype = ctypes.c_int
+    lib.likwid_getBugfixVersion.restype = ctypes.c_int
 
+    major = lib.likwid_getMajorVersion()
+    release = lib.likwid_getMinorVersion()
+    minor = lib.likwid_getBugfixVersion()
+
+    extra_args.extend([
+        f"-DLIKWID_MAJOR={major}",
+        f"-DLIKWID_RELEASE={release}",
+        f"-DLIKWID_MINOR={minor}",
+    ])
     return extra_args
 
+def get_libraries():
+    libs = [LIKWID_LIB]
+    # bstrlib is bundled into liblikwid on some installs but separate on others
+    bstrlib = glob.glob(os.path.join(LIKWID_LIBPATH, "libbstr*.so*"))
+    if bstrlib:
+        libs.append("bstr")
+    return libs
 
-pylikwid = Extension("pylikwid",
-                     include_dirs=[LIKWID_INCPATH],
-                     libraries=[LIKWID_LIB],
+
+def get_include_dirs():
+    include_dirs = ["src/pylikwid", LIKWID_INCPATH]
+    likwid_subdir = os.path.join(LIKWID_INCPATH, "likwid")
+    if os.path.isdir(likwid_subdir):
+        include_dirs.append(likwid_subdir)
+    return include_dirs
+
+pylikwid = Extension("pylikwid.pylikwid",
+                     include_dirs=get_include_dirs(),
+                     libraries=get_libraries(),
                      library_dirs=[LIKWID_LIBPATH],
+                     runtime_library_dirs=[LIKWID_LIBPATH],
                      extra_compile_args=get_extra_compile_args(),
-                     sources=["pylikwid.c"])
+                     sources = ["src/pylikwid/pylikwid.c"],
+                     py_limited_api=True,
+)
 
 setup(
     name="pylikwid",
     version="0.4.2",
-    author="Thomas Roehl",
+    author="Thomas Gruber",
     author_email="thomas.roehl@googlemail.com",
-    description="A Python module to access the function of the LIKWID library",
-    long_description=read("README.rst"),
+    description="A Python module to access the functions of the LIKWID library",
     license="GPLv2",
-    keywords="hpc performance benchmark analysis",
-    url="https://github.com/RRZE-HPC/pylikwid",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Software Development",
-        "Topic :: Utilities",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-    ],
-    package_data={
-        "pylikwid": ["pylikwid.c", "README.rst", "LICENSE"],
-        "tests": ["tests/*.py"],
-    },
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
     ext_modules=[pylikwid],
 )

--- a/src/pylikwid/__init__.py
+++ b/src/pylikwid/__init__.py
@@ -1,0 +1,1 @@
+from .pylikwid import *

--- a/src/pylikwid/pylikwid.c
+++ b/src/pylikwid/pylikwid.c
@@ -3,6 +3,10 @@
 
 #include <likwid.h>
 
+#if !(LIKWID_MAJOR == 5 && LIKWID_RELEASE >= 4)
+#include <bstrlib.h>
+#endif
+
 #define PYSTR(str) (Py_BuildValue("s", str))
 #define PYINT(val) (Py_BuildValue("i", val))
 #define PYUINT(val) (Py_BuildValue("I", val))

--- a/src/pylikwid/pylikwid.c
+++ b/src/pylikwid/pylikwid.c
@@ -249,13 +249,13 @@ likwid_hpmmode(PyObject *self, PyObject *args)
 {
     int mode;
     if (!PyArg_ParseTuple(args, "i", &mode))
-        return Py_False;
+        Py_RETURN_FALSE;
     if ((mode == ACCESSMODE_DIRECT) || (mode == ACCESSMODE_DAEMON))
     {
         HPMmode(mode);
-        return Py_True;
+        Py_RETURN_TRUE;
     }
-    return Py_False;
+    Py_RETURN_FALSE;
 }
 
 static PyObject *
@@ -265,9 +265,9 @@ likwid_hpminit(PyObject *self, PyObject *args)
     if (err == 0)
     {
         access_initialized = 1;
-        return Py_True;
+        Py_RETURN_TRUE;
     }
-    return Py_False;
+    Py_RETURN_FALSE;
 }
 
 static PyObject *
@@ -302,28 +302,28 @@ static PyObject *
 likwid_initconfiguration(PyObject *self, PyObject *args)
 {
     if (config_initialized)
-        return Py_True;
+        Py_RETURN_TRUE;
     int ret = init_configuration();
     if (ret == 0)
     {
         config_initialized = 1;
-        return Py_True;
+        Py_RETURN_TRUE;
     }
-    return Py_False;
+    Py_RETURN_FALSE;
 }
 
 static PyObject *
 likwid_destroyconfiguration(PyObject *self, PyObject *args)
 {
     if (!config_initialized)
-        return Py_False;
+        Py_RETURN_FALSE;
     int ret = destroy_configuration();
     if (ret == 0)
     {
         config_initialized = 0;
-        return Py_True;
+        Py_RETURN_TRUE;
     }
-    return Py_False;
+    Py_RETURN_FALSE;
 }
 
 static PyObject *
@@ -359,13 +359,13 @@ likwid_setgrouppath(PyObject *self, PyObject *args)
     int ret = 0;
     char* grouppath;
     if (!PyArg_ParseTuple(args, "s", &grouppath))
-        return Py_False;
+        Py_RETURN_FALSE;
     ret = config_setGroupPath(grouppath);
     if (ret == 0)
     {
-        return Py_True;
+        Py_RETURN_TRUE;
     }
-    return Py_False;
+    Py_RETURN_FALSE;
 }
 
 /*
@@ -381,9 +381,9 @@ likwid_inittopology(PyObject *self, PyObject *args)
     if (ret == 0)
     {
         topo_initialized = 1;
-        return Py_True;
+        Py_RETURN_TRUE;
     }
-    return Py_False;
+    Py_RETURN_FALSE;
 }
 
 static PyObject *


### PR DESCRIPTION
Closes #24 

**Repo restructuring**

- Added a `pyproject.toml` (moved metadata from `setup.py` to `pyproject.toml`)
- Moved source files to `src/pylikwid`
- Added an `__init__.py` `src/pylikwid` which exposes all pylikwid functions to the user

**Fixes**
- All LIKWID_MAJOR, LIKWID_RELEASE, LIKWID_MINOR, VERSION, RELEASE, MINORVERSION defines passed to compiler
- Replaced `return Py_True/return Py_False` with `Py_RETURN_TRUE/Py_RETURN_FALSE`
- In `setup.py`, I added `get_include_dirs()` so `bstrlib` can be added
- In `setup.py`, I added `get_libraries()` so `os.path.join(LIKWID_INCPATH, "likwid")` is included if it exists
- In `setup.py`, I added `get_sources()` so `bstrlib.c` is added `if not (major == 5 and release >= 4):`